### PR TITLE
[bugfix] edit no violence scene error

### DIFF
--- a/pipeline/score2figure.py
+++ b/pipeline/score2figure.py
@@ -42,9 +42,9 @@ def get_interval(off_path, threshold_value):
     not_violent_scene = sorted(list(set(np.array(not_violent_scene) // 24)))
     print(not_violent_scene)
 
-    if not_violent_scene:
+    save_scene = []
 
-        save_scene = []
+    if not_violent_scene:
 
         queue = deque(not_violent_scene)
 


### PR DESCRIPTION
save_scene position edit in score2figure.py
- threshold를 높게 설정하여 폭력구간이 없을 때 에러가 발생하였습니다.
- 변수 선언 위치를 수정하여 디버깅하였습니다.

[error]
Details: local variable 'save_scene' referenced before assignment

![image](https://user-images.githubusercontent.com/82289435/172051097-0aa436d8-289a-41e9-9123-6da3c7a07bf3.png)
